### PR TITLE
Add setUrl convenience method to SeoHelper

### DIFF
--- a/src/SeoHelper.php
+++ b/src/SeoHelper.php
@@ -253,6 +253,21 @@ class SeoHelper implements SeoHelperContract
         return $this;
     }
 
+    /**
+     * Set the current URL.
+     * 
+     * @param  string  $url
+     *
+     * @return \Arcanedev\SeoHelper\SeoHelper
+     */
+    public function setUrl($url)
+    {
+        $this->meta()->setUrl($url);
+        $this->openGraph()->setUrl($url);
+
+        return $this;
+    }
+
     /* -----------------------------------------------------------------
      |  Main Methods
      | -----------------------------------------------------------------

--- a/tests/SeoHelperTest.php
+++ b/tests/SeoHelperTest.php
@@ -229,6 +229,23 @@ class SeoHelperTest extends TestCase
             static::assertStringContainsString($expected, $rendered);
         }
     }
+    
+    /** @test */
+    public function it_can_set_and_render_url()
+    {
+        $this->seoHelper->setUrl($url = 'http://localhost/path');
+
+        $expectations = [
+            '<link rel="canonical" href="'.$url.'">',
+            '<meta property="og:url" content="'.$url.'">'
+        ];
+
+        $rendered = $this->seoHelper->render();
+
+        foreach ($expectations as $expected) {
+            static::assertStringContainsString($expected, $rendered);
+        }
+    }
 
     /** @test */
     public function it_can_render_all()


### PR DESCRIPTION
It's now possible to set the current url across all managers with one call.