### PR TITLE
Google Analytics snippet is upgraded to new gtag.js snippet.

### DIFF
--- a/src/Entities/Analytics.php
+++ b/src/Entities/Analytics.php
@@ -112,14 +112,13 @@ class Analytics implements AnalyticsContract
             return '';
 
         return <<<EOT
+<script async src="https://www.googletagmanager.com/gtag/js?id=$this->google"></script>
 <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-    ga('create', '$this->google', 'auto');
-    ga('send', 'pageview');
+  gtag('config', '$this->google');
 </script>
 EOT;
     }


### PR DESCRIPTION
Google has new gtag.js which is backward compatible. However, new Analytics Beta program users are getting a different code which is not compatible with old gtag snippet code. Site verifications on search console etc is broken with old snippet / new code.
See:
https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs